### PR TITLE
feat: 로그인 페이지를 구현한다

### DIFF
--- a/src/components/common/LogoCircle.tsx
+++ b/src/components/common/LogoCircle.tsx
@@ -1,0 +1,11 @@
+import { Avatar } from '@mui/material';
+import logo from '../../assets/logos/logo_white.png';
+
+function LogoCircle() {
+  return (
+    <Avatar sx={{ bgcolor: 'primary.main', width: 100, height: 100 }}>
+      <img src={logo} alt="" width="50px" height="50px" />
+    </Avatar>
+  );
+}
+export default LogoCircle;

--- a/src/components/layouts/CenterBox.tsx
+++ b/src/components/layouts/CenterBox.tsx
@@ -1,0 +1,16 @@
+import { Box } from '@mui/material';
+import { PropsWithChildren } from 'react';
+
+function CenterBox({ children }: PropsWithChildren) {
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minHeight="100vh"
+    >
+      {children}
+    </Box>
+  );
+}
+export default CenterBox;

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,0 +1,1 @@
+export const SESSION_STORAGE_KEY_IS_AUTHENTICATED = 'is-authenticated'

--- a/src/containers/sign/signInContainer/Footer.tsx
+++ b/src/containers/sign/signInContainer/Footer.tsx
@@ -1,0 +1,17 @@
+import { Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+function Footer() {
+  return (
+    <Typography color="text.secondary">
+      {'Copyright © '}
+      <Link color="inherit" to="https://github.com/soyoung125/fin-the-pen-web-v2">
+        핀더펜
+      </Link>
+      {' '}
+      {new Date().getFullYear()}
+      .
+    </Typography>
+  );
+}
+export default Footer;

--- a/src/containers/sign/signInContainer/Header.tsx
+++ b/src/containers/sign/signInContainer/Header.tsx
@@ -1,0 +1,16 @@
+import { Stack, Typography } from '@mui/material';
+import LogoCircle from '../../../components/common/LogoCircle';
+
+function Header() {
+  return (
+    <>
+      <LogoCircle />
+      <Stack my={2}>
+        <Typography component="h1" variant="h5">
+          핀더펜과 함께 자산설계를 시작하세요!
+        </Typography>
+      </Stack>
+    </>
+  );
+}
+export default Header;

--- a/src/containers/sign/signInContainer/SignInFields.tsx
+++ b/src/containers/sign/signInContainer/SignInFields.tsx
@@ -24,6 +24,9 @@ function SignInFields() {
 
   const signInMutation = useMutation({
     mutationFn: signIn,
+    onSuccess: () => {
+      navigate('/');
+    },
     onSettled: () => queryClient.invalidateQueries({queryKey: ["user"]}),
   });
 

--- a/src/containers/sign/signInContainer/SignInFields.tsx
+++ b/src/containers/sign/signInContainer/SignInFields.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, TextField } from '@mui/material';
+import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import PATH from '../../../domain/constants/path';
+
+function SignInFields() {
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const sign = {
+      user_id: data.get('email'),
+      password: data.get('password'),
+    };
+    alert(JSON.stringify(sign))
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      noValidate
+      sx={{ maxWidth: '400px' }}
+    >
+
+      <TextField
+        margin="normal"
+        required
+        fullWidth
+        id="email"
+        label="Email Address"
+        name="email"
+        autoComplete="email"
+        autoFocus
+      />
+      <TextField
+        margin="normal"
+        required
+        fullWidth
+        name="password"
+        label="Password"
+        type="password"
+        id="password"
+        autoComplete="current-password"
+      />
+
+      <Button onClick={() => alert('You forget a thousand things every day. Make sure this is one of them :)')}>
+        비밀번호를 잊으셨나요?
+      </Button>
+
+      <Button
+        type="submit"
+        fullWidth
+        variant="contained"
+        sx={{ mt: 3, mb: 2 }}
+      >
+        로그인
+      </Button>
+
+      <Button onClick={() => navigate(PATH.signUp)}>
+        계정이 없으신가요?
+      </Button>
+    </Box>
+  );
+}
+export default SignInFields;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import router from './app/router.tsx';
 import { RouterProvider } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 import { worker } from './mocks/browser';
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 async function main() {
   // msw 세팅 시작
@@ -16,9 +19,11 @@ async function main() {
   });
   // msw 세팅 끝
   ReactDOM.createRoot(document.getElementById('root')!).render(
-    <RecoilRoot>
-      <RouterProvider router={router} />
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <RouterProvider router={router} />
+      </RecoilRoot>
+    </QueryClientProvider>
   );
 }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
 // src/mocks/handlers.js
-import { rest } from 'msw'
+import {rest} from 'msw'
 
 export const handlers = [
   rest.post('/login', (req, res, ctx) => {
@@ -34,4 +34,22 @@ export const handlers = [
       }),
     )
   }),
+
+  rest.post('/fin-the-pen-web/sign-in', (req, res, ctx) => {
+    alert('서버가 정상적으로 동작하지 않지만 게스트 모드로 로그인 합니다.')
+
+    return res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json({
+        id: -1,
+        user_id: 'guest@finthepen.com',
+        name: '게스트',
+        bday: '2023-07-25',
+        registerDate: '2023-01-01',
+        phone_number: '010-1234-5678'
+      })
+    )
+  }),
+
 ]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,12 +1,13 @@
 // src/mocks/handlers.js
 import {rest} from 'msw'
 import {getSessionStorage, setSessionStorage} from "../utils/storage.ts";
+import {SESSION_STORAGE_KEY_IS_AUTHENTICATED} from "../constants/keys.ts";
 
 export const handlers = [
 
   rest.post('/fin-the-pen-web/sign-in', (req, res, ctx) => {
     alert('서버가 정상적으로 동작하지 않지만 게스트 모드로 로그인 합니다.')
-    setSessionStorage('is-authenticated', true); //JWT나 Basic으로 이전 예정
+    setSessionStorage(SESSION_STORAGE_KEY_IS_AUTHENTICATED, true); //JWT나 Basic으로 이전 예정
 
     return res(
       ctx.status(200),
@@ -15,8 +16,7 @@ export const handlers = [
   }),
 
   rest.post('/fin-the-pen-web/user', (req, res, ctx) => {
-    const isAuthenticated = getSessionStorage<boolean>('is-authenticated', false)
-    console.log(isAuthenticated)
+    const isAuthenticated = getSessionStorage<boolean>(SESSION_STORAGE_KEY_IS_AUTHENTICATED, false)
     if (isAuthenticated) {
       console.log('is-authenticated')
       return res(
@@ -34,7 +34,7 @@ export const handlers = [
     }
     return res(
       ctx.status(403),
-      ctx.delay(1000),
+      ctx.delay(100),
     )
   }),
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,54 +1,40 @@
 // src/mocks/handlers.js
 import {rest} from 'msw'
+import {getSessionStorage, setSessionStorage} from "../utils/storage.ts";
 
 export const handlers = [
-  rest.post('/login', (req, res, ctx) => {
-    // Persist user's authentication in the session
-    sessionStorage.setItem('is-authenticated', 'true')
-
-    return res(
-      // Respond with a 200 status code
-      ctx.status(200),
-    )
-  }),
-
-  rest.get('/user', (req, res, ctx) => {
-    // Check if the user is authenticated in this session
-    const isAuthenticated = sessionStorage.getItem('is-authenticated')
-
-    if (!isAuthenticated) {
-      // If not authenticated, respond with a 403 error
-      return res(
-        ctx.status(403),
-        ctx.json({
-          errorMessage: 'Not authorized',
-        }),
-      )
-    }
-
-    // If authenticated, return a mocked user details
-    return res(
-      ctx.status(200),
-      ctx.json({
-        username: 'admin',
-      }),
-    )
-  }),
 
   rest.post('/fin-the-pen-web/sign-in', (req, res, ctx) => {
     alert('서버가 정상적으로 동작하지 않지만 게스트 모드로 로그인 합니다.')
+    setSessionStorage('is-authenticated', true); //JWT나 Basic으로 이전 예정
 
     return res(
       ctx.status(200),
       ctx.delay(1000),
-      ctx.json({
-        id: -1,
-        user_id: 'guest@finthepen.com',
-        name: '게스트',
-        bday: '2023-07-25',
-        registerDate: '2023-01-01',
-        phone_number: '010-1234-5678'
-      })
+    )
+  }),
+
+  rest.post('/fin-the-pen-web/user', (req, res, ctx) => {
+    const isAuthenticated = getSessionStorage<boolean>('is-authenticated', false)
+    console.log(isAuthenticated)
+    if (isAuthenticated) {
+      console.log('is-authenticated')
+      return res(
+        ctx.status(200),
+        ctx.delay(1000),
+        ctx.json({
+          id: -1,
+          user_id: 'guest@finthepen.com',
+          name: '게스트',
+          bday: '2023-07-25',
+          registerDate: '2023-01-01',
+          phone_number: '010-1234-5678'
+        })
+      )
+    }
+    return res(
+      ctx.status(403),
+      ctx.delay(1000),
     )
   }),
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -4,7 +4,7 @@ import {User} from "../../types";
 export const fetchUser = async () =>
   fetch("/fin-the-pen-web/user", {
     method: "POST"
-    //   이후 헤더에서 로그인 토큰을 넘겨줘야함
+    //   이후 헤더에서 로그인 토큰을 넘겨줘야 함
   }).then((res) => res.json());
 
 function MyPage() {

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,6 +1,38 @@
+import {useQuery} from "@tanstack/react-query";
+import {User} from "../../types";
+
+export const fetchUser = async () =>
+  fetch("/fin-the-pen-web/user", {
+    method: "POST"
+    //   이후 헤더에서 로그인 토큰을 넘겨줘야함
+  }).then((res) => res.json());
+
 function MyPage() {
+  const {data, isSuccess, isLoading, isError} = useQuery<User>({
+    queryKey: ["user"],
+    queryFn: fetchUser
+  })
+
+  if (isLoading) {
+    return <div>⌛</div>;
+  }
+
   return (
-    <>MyPage</>
+    <div>
+      <div>
+        MyPage
+      </div>
+      {
+        isSuccess && (
+          <div>data:{JSON.stringify(data)}</div>
+        )
+      }
+      {
+        isError && (
+          <div>로그인 하세요</div>
+        )
+      }
+    </div>
   )
 }
 

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,6 +1,7 @@
 import Footer from "../../containers/sign/signInContainer/Footer.tsx";
 import {Stack} from "@mui/material";
 import CenterBox from "../../components/layouts/CenterBox.tsx";
+import Header from "../../containers/sign/signInContainer/Header.tsx";
 
 function SignIn() {
   return(
@@ -10,6 +11,7 @@ function SignIn() {
         alignItems="center"
         px={1}
       >
+        <Header/>
         <Footer />
       </Stack>
 

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,0 +1,20 @@
+import Footer from "../../containers/sign/signInContainer/Footer.tsx";
+import {Stack} from "@mui/material";
+import CenterBox from "../../components/layouts/CenterBox.tsx";
+
+function SignIn() {
+  return(
+    <CenterBox>
+      <Stack
+        justifyContent="center"
+        alignItems="center"
+        px={1}
+      >
+        <Footer />
+      </Stack>
+
+    </CenterBox>
+  )
+}
+
+export default SignIn;

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -2,6 +2,7 @@ import Footer from "../../containers/sign/signInContainer/Footer.tsx";
 import {Stack} from "@mui/material";
 import CenterBox from "../../components/layouts/CenterBox.tsx";
 import Header from "../../containers/sign/signInContainer/Header.tsx";
+import SignInFields from "../../containers/sign/signInContainer/SignInFields.tsx";
 
 function SignIn() {
   return(
@@ -12,6 +13,7 @@ function SignIn() {
         px={1}
       >
         <Header/>
+        <SignInFields/>
         <Footer />
       </Stack>
 

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -1,8 +1,2 @@
-function SignIn() {
-  return(
-    <>SignIn</>
-  )
-}
-  
-export default SignIn;
-  
+import SignIn from './SignIn.tsx'
+export default SignIn

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  user_id: string;
+  name: string;
+  bday: string;
+  registerDate: string;
+  phone_number: string;
+}


### PR DESCRIPTION
로그인 페이지를 구현하였습니다.

기존의 로그인 방식과 다르게 msw 와 tanstack-query를 이용하여 구현하였습니다.


1. 현재는 로그인 버튼 누르면 그냥 자동으로 게스트 계정으로 로그인 되게 해놨습니다.
2. 로그인 여부는 /mypage 에서 확인 가능합니다.
3. 로그인 성공 시 어떤 토큰이 발급 되는 로직으로 개선했습니다. (백엔드에서 도움이 필요해서 당분간은 그냥 session storage에 isAuthenticated를 true로 만들어주려고 합니다.)
4. 이쪽 관련 로직은 이후에 개선될 예정임


close #22